### PR TITLE
Ruby3 compatibility with kwargs

### DIFF
--- a/lib/ruby_decorators.rb
+++ b/lib/ruby_decorators.rb
@@ -12,7 +12,7 @@ module RubyDecorators
 
     private
 
-    def resolve_method(method_name, args, klass:, &blk)
+    def resolve_method(method_name, args, kwargs, klass:, &blk)
       decorators = nil
       method = nil
       klass.ancestors.each do |klass|
@@ -27,8 +27,8 @@ module RubyDecorators
 
       decorators.inject(method.bind(self)) do |method, decorator|
         decorator = decorator.new if decorator.respond_to?(:new)
-        lambda { |*a, &b| decorator.call(method, *a, &b) }
-      end.call(*args, &blk)
+        lambda { |*a, **kw, &b| decorator.call(method, *a, **kw, &b) }
+      end.call(*args, **kwargs, &blk)
     end
   end
 
@@ -52,8 +52,8 @@ module RubyDecorators
 
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       #{method_visibility_for(method_name)}
-      def #{method_name}(*args, &blk)
-        resolve_method(:#{method_name}, args, klass: #{self}, &blk)
+      def #{method_name}(*args, **kwargs, &blk)
+        resolve_method(:#{method_name}, args, kwargs, klass: #{self}, &blk)
       end
     RUBY_EVAL
   end

--- a/spec/ruby_decorators_spec.rb
+++ b/spec/ruby_decorators_spec.rb
@@ -14,8 +14,8 @@ describe RubyDecorators do
   end
 
   class Batman < RubyDecorator
-    def call(this, *args, &blk)
-      this.call(*args, &blk).sub('world', 'batman')
+    def call(this, *args, **kwargs, &blk)
+      this.call(*args, **kwargs, &blk).sub('world', 'batman')
     end
   end
 

--- a/spec/ruby_decorators_spec.rb
+++ b/spec/ruby_decorators_spec.rb
@@ -88,6 +88,11 @@ describe RubyDecorators do
       "#{@greeting} #{arg1} #{arg2} #{block.call if block_given?}"
     end
 
+    +Batman
+    def hello_with_block_and_kwargs(arg1, arg2, opt:, &block)
+      "#{@greeting} #{arg1} #{arg2} opt:#{opt} #{block.call if block_given?}"
+    end
+
     +Catwoman.new('super', 'catwoman')
     def hello_super_catwoman
       @greeting
@@ -180,6 +185,10 @@ describe RubyDecorators do
 
     it "decorates a method with a block" do
       subject.hello_with_block('how are', 'you') { 'man?' }.must_equal 'hello batman how are you man?'
+    end
+
+    it "decorates a method with a block and kwargs" do
+      subject.hello_with_block_and_kwargs('how are', 'you', opt: 'optval') { 'man?' }.must_equal 'hello batman how are you opt:optval man?'
     end
 
     it "ignores undecorated methods" do


### PR DESCRIPTION
Version `0.0.4` does not work correctly decorating a method that accepts keyword arguments with Ruby 3.0+

Ruby 3 code [needs to specify the keyword args explicitly](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#:~:text=You%20need%20to%20explicitly%20delegate%20keyword%20arguments)

This code change passes tests with Ruby 2.7.3 and Ruby 3.0.3